### PR TITLE
use websocket branch that supports tls proxy

### DIFF
--- a/.github/workflows/build-go.yaml
+++ b/.github/workflows/build-go.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: setup
         run: |
           go version
-          go get github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.42.1
           go get github.com/securego/gosec/cmd/gosec
           #go get golang.org/x/tools/cmd/cover
           go get github.com/axw/gocov/gocov

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 )
 
-replace github.com/gorilla/websocket v1.4.2 => github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa
+replace github.com/gorilla/websocket v1.4.2 => github.com/philipatl/websocket v1.4.3-0.20211206152948-d16969baa130

--- a/go.mod
+++ b/go.mod
@@ -6,3 +6,5 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/smartystreets/goconvey v1.6.4
 )
+
+replace github.com/gorilla/websocket v1.4.2 => github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 )
 
-replace github.com/gorilla/websocket v1.4.2 => github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa
+replace github.com/gorilla/websocket v1.4.2 => github.com/philipatl/websocket v1.4.3-0.20211129230113-2d61589eda82

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 	github.com/smartystreets/goconvey v1.6.4
 )
 
-replace github.com/gorilla/websocket v1.4.2 => github.com/philipatl/websocket v1.4.3-0.20211129230113-2d61589eda82
+replace github.com/gorilla/websocket v1.4.2 => github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/philipatl/websocket v1.4.3-0.20211129230113-2d61589eda82 h1:f6YyQVtz72GZMRjzBHCXA5eWXPo5MUp2AZYJa/t5kkY=
-github.com/philipatl/websocket v1.4.3-0.20211129230113-2d61589eda82/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa h1:tJDpe2spTablhjihxSsCekcgHtmJa5wXflr4WlybVXk=
+github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa h1:tJDpe2spTablhjihxSsCekcgHtmJa5wXflr4WlybVXk=
-github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/philipatl/websocket v1.4.3-0.20211206152948-d16969baa130 h1:tfBfrzOsX9Fblri3B2SCyp5JJcHlqVgU+M9aF6hqF4o=
+github.com/philipatl/websocket v1.4.3-0.20211206152948-d16969baa130/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,9 @@
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa h1:tJDpe2spTablhjihxSsCekcgHtmJa5wXflr4WlybVXk=
+github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGa
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
-github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa h1:tJDpe2spTablhjihxSsCekcgHtmJa5wXflr4WlybVXk=
-github.com/philipatl/websocket v1.4.3-0.20211129194947-7f3a5bcae0fa/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/philipatl/websocket v1.4.3-0.20211129230113-2d61589eda82 h1:f6YyQVtz72GZMRjzBHCXA5eWXPo5MUp2AZYJa/t5kkY=
+github.com/philipatl/websocket v1.4.3-0.20211129230113-2d61589eda82/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=


### PR DESCRIPTION
## Description

I forked the gorilla/websocket repo, and made changes to support use with an https proxy.
This PR uses that fork.

https://github.com/philipatl/websocket/tree/tls-proxy
https://github.com/gorilla/websocket/pull/740

## Motivation and Context

It is needed for enforcer to proxy websocket connections.
See CNS-3317

## How Has This Been Tested?

Verified that enforcer correctly proxies websocket connections, using an https proxy.
Integration and functional tests of enforcer are in the works.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- New feature (non-breaking change which adds functionality)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
